### PR TITLE
@broskoski - adds pusher auth endpoint and initial support for monitoring monoliths

### DIFF
--- a/api/feed/routes.coffee
+++ b/api/feed/routes.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 ig = require('instagram-node').instagram()
 Q = require 'q'
+
 { INSTAGRAM_CLIENT_ID, INSTAGRAM_CLIENT_SECRET } = process.env
 { Tag, Entry } = require '../lib/models.coffee'
 

--- a/api/index.coffee
+++ b/api/index.coffee
@@ -1,11 +1,19 @@
 require('node-env-file')("#{process.cwd()}/.env") unless process.env.NODE_ENV?
 express = require "express"
 bodyParser = require 'body-parser'
-{ NODE_ENV, ARTSY_URL, ARTSY_ID, ARTSY_SECRET, MONGOLAB_URI, INSTAGRAM_CLIENT_ID, INSTAGRAM_CLIENT_SECRET} = process.env
+
+{ NODE_ENV, ARTSY_URL, ARTSY_ID, ARTSY_SECRET, MONGOLAB_URI, INSTAGRAM_CLIENT_ID, INSTAGRAM_CLIENT_SECRET, PUSHER_APP_ID, PUSHER_KEY, PUSHER_SECRET} = process.env
+
 ig = require('instagram-node').instagram()
 debug = require('debug') 'api'
 cors = require 'cors'
 mongoose = require 'mongoose'
+Pusher = require 'pusher'
+
+pusher = new Pusher
+  appId:  PUSHER_APP_ID
+  key:    PUSHER_KEY
+  secret: PUSHER_SECRET
 
 app = module.exports = express()
 
@@ -21,6 +29,13 @@ app.use bodyParser.json()
 app.use require './tags'
 app.use require './entries'
 app.use require './feed'
+
+# Routes
+app.post '/pusher/auth', (req, res) ->
+  socketId = req.body.socket_id
+  channel = req.body.channel_name
+  auth = pusher.authenticate socketId, channel, user_id: req.body.client_id
+  res.send auth
 
 app.get '/system/up', (req, res) ->
   res.status(200).send { up: true }

--- a/api/lib/models.coffee
+++ b/api/lib/models.coffee
@@ -1,4 +1,5 @@
 mongoose = require 'mongoose'
+findOrCreate = require 'mongoose-findorcreate'
 
 entrySchema = new mongoose.Schema
   external_id:
@@ -22,8 +23,3 @@ tagSchema = new mongoose.Schema
     required: true
 
 module.exports.Tag = Tag = mongoose.model 'Tag', tagSchema
-
-scheduleSchema = new mongoose.Schema
-  contents: {}
-
-module.exports.Schedule = Schedule = mongoose.model 'Schedule', scheduleSchema

--- a/client/apps/dashboard/client/index.coffee
+++ b/client/apps/dashboard/client/index.coffee
@@ -19,8 +19,6 @@ class FeedView extends Backbone.View
     $entry = $el.closest('.entry')
     id = $entry.data('id')
 
-    console.log 'get from event', $entry, id, @collection.get id
-
     entry = @collection.get id
 
     {id: id, $entry: $entry, entry: entry}

--- a/client/apps/monoliths/client/view.coffee
+++ b/client/apps/monoliths/client/view.coffee
@@ -1,0 +1,37 @@
+init = require '../../../components/layout/client.coffee'
+sd = require('sharify').data
+_ = require 'underscore'
+$ = require 'jquery'
+Backbone = require 'backbone'
+Backbone.$ = $
+EuropaPusher = require '../../../models/europa_pusher.coffee'
+
+presenceTemplate = -> require('../templates/presence.jade') arguments...
+
+class ConsoleView extends Backbone.View
+
+  events:
+    'click .reset' : 'resetMonolith'
+
+  initialize: ->
+    @pusher = new EuropaPusher
+    @$columns = @$ '.layout__content__main--console__columns'
+
+    @pusher.bindChannel 'presence', 'pusher:subscription_succeeded', @showOnlineMonoliths
+    @pusher.bindChannel 'presence', 'pusher:member_added', @showOnlineMonoliths
+    @pusher.bindChannel 'presence', 'pusher:member_removed', @showOnlineMonoliths
+
+  showOnlineMonoliths: =>
+    @$columns.html presenceTemplate members: @pusher.getMembers('presence')
+
+  resetMonolith: (e)=>
+    $member = $(e.currentTarget).closest('.monolith-columns__list__member')
+    monolithId = $member.data('name')
+
+    @pusher.triggerEvent "command", 'restart', monolithId
+
+module.exports.init = ->
+  init()
+
+  new ConsoleView
+    el: $('.layout__content__main')

--- a/client/apps/monoliths/index.coffee
+++ b/client/apps/monoliths/index.coffee
@@ -1,0 +1,9 @@
+express = require 'express'
+routes = require './routes'
+
+app = module.exports = express()
+
+app.set 'views', "#{__dirname}/templates"
+app.set 'view engine', 'jade'
+
+app.get '/monoliths', routes.index

--- a/client/apps/monoliths/routes.coffee
+++ b/client/apps/monoliths/routes.coffee
@@ -1,0 +1,8 @@
+_ = require 'underscore'
+
+@index = (req, res, next) ->
+  res.render 'index'
+
+
+
+

--- a/client/apps/monoliths/stylesheets/index.styl
+++ b/client/apps/monoliths/stylesheets/index.styl
@@ -1,0 +1,27 @@
+@import '../../../components/stylus_lib'
+
+.layout__content__main--console
+  monospace()
+  min-height 100%
+  position absolute
+  width 100%
+  left 110px
+  padding 20px
+
+.layout__content__main--console__columns
+  color #000
+
+  h3
+    font-weight normal
+    color green-color
+
+.monolith-columns__list
+  display table
+  width 100%
+  max-width 800px
+
+.monolith-columns__list__member
+  display table-row
+
+.monolith-columns__list__member__attr
+  display table-cell

--- a/client/apps/monoliths/templates/index.jade
+++ b/client/apps/monoliths/templates/index.jade
@@ -1,0 +1,10 @@
+extend ../../../components/layout/templates/index
+
+block content
+  .layout__content__header
+    .layout__content__header__title Monolith Console
+
+  .layout__content__main.layout__content__main--console
+
+    .layout__content__main--console__columns
+      //- rendered by client

--- a/client/apps/monoliths/templates/presence.jade
+++ b/client/apps/monoliths/templates/presence.jade
@@ -1,0 +1,11 @@
+h3 Online
+.monolith-columns__list
+  if members.length
+    for member in members
+      .monolith-columns__list__member(data-name="#{member.name}")
+        .monolith-columns__list__member__attr= member.name
+        .monolith-columns__list__member__attr= member.connected_at
+        .monolith-columns__list__member__attr: button.avant-garde-button.reset Reset
+  else
+    span No monoliths online
+

--- a/client/assets/all.styl
+++ b/client/assets/all.styl
@@ -1,2 +1,3 @@
 @import '../components/layout/stylesheets'
 @import '../apps/dashboard/stylesheets'
+@import '../apps/monoliths/stylesheets'

--- a/client/assets/main.coffee
+++ b/client/assets/main.coffee
@@ -6,6 +6,9 @@ hash =
   '^$': ->
     require('../apps/dashboard/client/index.coffee').init()
 
+  '^/monoliths': ->
+    require('../apps/monoliths/client/view.coffee').init()
+
 # On DOM load iterate through the hash and load that app's JS
 $ ->
   for regexStr, load of hash

--- a/client/components/layout/stylesheets/index.styl
+++ b/client/components/layout/stylesheets/index.styl
@@ -32,5 +32,8 @@ input
   font-size default-garamond-font-size
   background-color transparent
 
+monospace()
+  font-family 'Inconsolata', Courier
+
 @import 'sidebar'
 @import 'main'

--- a/client/components/layout/templates/index.jade
+++ b/client/components/layout/templates/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
   head
+    link(href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css')
     link( type='text/css' rel='stylesheet' href=asset('/assets/all.css') )
     title Europa
   body.layout
@@ -15,6 +16,11 @@ html(lang="en")
       type="text/javascript"
       src="//fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"
     )
+
+    //- Pusher
+    script(
+      type='text/javascript'
+      src='http://js.pusher.com/2.1/pusher.min.js')
 
     //- Asset package
     script( src=asset('/assets/main.js') )

--- a/client/components/layout/templates/sidebar.jade
+++ b/client/components/layout/templates/sidebar.jade
@@ -8,4 +8,8 @@ nav.layout__sidebar
       .layout__sidebar__menu-icon
       .layout__sidebar__menu-text Feed
 
+    a.layout__sidebar__menu-item(href="/monoliths")
+      .layout__sidebar__menu-icon
+      .layout__sidebar__menu-text Monoliths
+
 

--- a/client/components/layout/templates/sidebar.jade
+++ b/client/components/layout/templates/sidebar.jade
@@ -8,8 +8,4 @@ nav.layout__sidebar
       .layout__sidebar__menu-icon
       .layout__sidebar__menu-text Feed
 
-    a.layout__sidebar__menu-item(href="/Schedule")
-      .layout__sidebar__menu-icon
-      .layout__sidebar__menu-text Schedule
-
 

--- a/client/lib/setup/index.coffee
+++ b/client/lib/setup/index.coffee
@@ -7,7 +7,7 @@ _ = require 'underscore'
 sharify = require 'sharify'
 sd = sharify.data = _.pick process.env,
   'APP_URL', 'API_URL', 'NODE_ENV', 'FORCE_URL', 'ARTSY_URL', 'GEMINI_KEY',
-  'SENTRY_PUBLIC_DSN', 'LOCAL_API_KEY'
+  'SENTRY_PUBLIC_DSN', 'LOCAL_API_KEY', 'PUSHER_KEY'
 
 bucketAssets = require 'bucket-assets'
 express = require 'express'
@@ -45,7 +45,8 @@ module.exports = (app) ->
   app.use bodyParser.urlencoded()
 
   # Mount apps
-  app.use '/', auth, require '../../apps/dashboard'
+  app.use auth, require '../../apps/dashboard'
+  app.use auth, require '../../apps/monoliths'
 
   # Mount static middleware for sub apps, components, and project-wide
   fs.readdirSync(path.resolve __dirname, '../../apps').forEach (fld) ->

--- a/client/models/europa_pusher.coffee
+++ b/client/models/europa_pusher.coffee
@@ -1,0 +1,39 @@
+_ = require 'underscore'
+sd = require('sharify').data
+$ = require 'jquery'
+
+module.exports = class EuropaPusher
+  name: "EUROPA"
+
+  constructor: (options) ->
+    @pusher = new Pusher sd.PUSHER_KEY,
+      authEndpoint: '/api/pusher/auth'
+      auth:
+        params: client_id: @name
+
+    @subscribeToChannels()
+
+  subscribeToChannels: ->
+    @channels =
+      command: @pusher.subscribe 'command'
+      presence: @pusher.subscribe 'presence-status'
+
+  bindChannel: (channelName, channelEvent, callback) =>
+    @channels[channelName].bind channelEvent, callback
+
+  getMembers: (channelName)->
+    members = @channels[channelName].members.members
+    return _.reject members, (member, name) => name is @name
+
+  triggerEvent: (channel, channelEvent, data) ->
+    $.ajax
+      url:'/api/pusher/publish'
+      type: 'POST'
+      data:
+        channel: channel
+        event: channelEvent
+        data: data
+      success: (res)-> console.log 'published event', res
+      error: (res, error) -> console.log 'error', error
+
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "instagram-node": "*",
     "q": "*",
     "passport": "*",
-    "passport-oauth2" : "*",
+    "passport-oauth2": "*",
     "cookie-session": "*",
     "nib": "",
     "ezel-assets": "*",
@@ -33,6 +33,7 @@
     "bucket-assets": "*",
     "basic-auth": "*",
     "moment": "*",
+    "pusher": "^1.0.3",
     "artsy-backbone-mixins": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-force-ssl": "*",
     "deamdify": "*",
     "mongoose": "*",
+    "mongoose-findorcreate": "*",
     "instagram-node": "*",
     "q": "*",
     "passport": "*",


### PR DESCRIPTION
Does the initial work of setting up Pusher auth and trigger endpoints so that the Europa admin app can monitor the state of Monolith instances.  After this the plan is to add support to trigger route changes in a monolith as well as retrieving the current route.
